### PR TITLE
Allow editing of gdocs in markdown with pandoc

### DIFF
--- a/autoload/metarw/gdrive.vim
+++ b/autoload/metarw/gdrive.vim
@@ -70,17 +70,32 @@ function! s:read_content(_, ...)
     endif
     return s:read_content(a:_, 1)
   endif
-  if !has_key(res, 'downloadUrl')
-    return ['error', 'This file seems impossible to edit in vim!']
+
+  let b:pandoc_converted = 0
+
+  if has_key(res, 'downloadUrl')
+    let downloadUrl = res.downloadUrl
+    let fileExt = res.fileExtension
+  else
+    let downloadUrl = res.exportLinks["text/html"]
+    let b:pandoc_converted = 1
+    let fileExt = "md"
+    " return ['error', 'This file seems impossible to edit in vim! ' . jsonString ]
   endif
-  let resp = webapi#http#get(res.downloadUrl, '', {'Authorization': 'Bearer ' . s:settings['access_token']})
+
+  let resp = webapi#http#get(downloadUrl, '', {'Authorization': 'Bearer ' . s:settings['access_token']})
   if resp.status !~ '^2'
     return ['error', resp.header[0]]
   endif
   let content = resp.content
+
+  if b:pandoc_converted
+    let content =  system("pandoc -s -f html -t markdown", content)
+  endif
+
   call setline(2, split(iconv(content, 'utf-8', &encoding), "\n"))
 
-  let ext = '.' . res.fileExtension
+  let ext = '.' . fileExt
   if has_key(s:extmap, ext)
     let &filetype = s:extmap[ext]
   endif
@@ -92,6 +107,15 @@ function! s:write_content(_, content, ...)
   if !s:load_settings()
     return ['error', v:errmsg]
   endif
+
+  if exists('b:pandoc_converted') && b:pandoc_converted
+    let content = system("pandoc -f markdown -t html", a:content)
+    let contenttype = 'text/html'
+  else
+    let content = a:content
+    let contenttype = 'application/octet-stream'
+  endif
+
   let id = a:_.id
   if !has_key(b:, 'metarw_gdrive_id')
     let title = id
@@ -99,7 +123,7 @@ function! s:write_content(_, content, ...)
     let res = webapi#json#decode(webapi#http#post('https://www.googleapis.com/drive/v2/files', webapi#json#encode({"title": title, "mimeType": "application/octet-stream", "description": "", "parents": [{"id": path}]}), {'Authorization': 'Bearer ' . s:settings['access_token'], 'Content-Type': 'application/json'}, 'POST').content)
     let id = res['id']
   endif
-  let res = webapi#json#decode(webapi#http#post('https://www.googleapis.com/upload/drive/v2/files/' . webapi#http#encodeURI(id), a:content, {'Authorization': 'Bearer ' . s:settings['access_token'], 'Content-Type': 'application/octet-stream'}, 'PUT').content)
+  let res = webapi#json#decode(webapi#http#post('https://www.googleapis.com/upload/drive/v2/files/' . webapi#http#encodeURI(id), content, {'Authorization': 'Bearer ' . s:settings['access_token'], 'Content-Type': contenttype}, 'PUT').content)
   if has_key(res, 'error')
     if res.error.code != 401 || a:0 != 0
       return ['error', res.error.message]
@@ -107,7 +131,7 @@ function! s:write_content(_, content, ...)
     if !s:refresh_token()
       return ['error', v:errmsg]
     endif
-    return s:write_content(a:_, a:content, 1)
+    return s:write_content(a:_, content, 1)
   endif
   return ['done', '']
 endfunction


### PR DESCRIPTION
I was trying out your plugin, great stuff!  I made some changes that you may be interested in.

vim-metarw-gdrive retrieves documents from google docs by looking for a
"downloadUrl" field in the api response.  This field will not be present
if the doc was created using google docs itself (a gdoc).  In order to
edit these simple documents, this patch requests google to export the
doc as html.  Back inside the plugin, this patch uses pandoc to convert
it to markdown.  The process is reversed when the file is saved from
within vim.

Note:  I'm guessing some folks will want to edit raw html (or whatever the gdoc is exported as).  In that case, the extra call to pandoc could be skipped (although, it would be great to have that included as an optional filter).
